### PR TITLE
Release TileDB-Py 0.24.1 against TileDB 2.18.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,12 +11,10 @@ source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
-# [win32]
-# [win and py2k]
 build:
   number: 0
-  skip: true
-  skip: true
+  skip: true  # [win32]
+  skip: true  # [win and py2k]
 requirements:
   build:
     - {{ compiler('cxx') }}


### PR DESCRIPTION
This reverts commit d02b4bd0c8b0a9b167f3d8963b2ad3c484d0fc77.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
