### PR TITLE
Avoid duplicate keys in recipe YAML

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,0 +1,6 @@
+@echo on
+
+set TILEDB_PATH=%LIBRARY_PREFIX%
+
+%PYTHON% -m pip install --no-build-isolation --no-deps --ignore-installed -v .
+if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -eux
+
+TILEDB_PATH=${PREFIX}
+
+$PYTHON -m pip install --no-build-isolation --no-deps --ignore-installed -v .

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,11 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  script: TILEDB_PATH=${PREFIX} {{ PYTHON }} -m pip install --no-build-isolation --no-deps --ignore-installed -v .  # [not win]
-  script: set "TILEDB_PATH=%LIBRARY_PREFIX%" && {{ PYTHON }} -m pip install --no-build-isolation --no-deps --ignore-installed -v .  # [win]
   number: 0
-  skip: true  # [win32]
-  skip: true  # [win and py2k]
 requirements:
   build:
     - {{ compiler('cxx') }}


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

---

This update is purely to make it easier to perform our nightly feedstock builds in [conda-forge-nightly-controller](https://github.com/TileDB-Inc/conda-forge-nightly-controller). In the script [`update-recipe.py`](https://github.com/TileDB-Inc/conda-forge-nightly-controller/blob/main/scripts/tiledb-py/update-recipe.py), we edit the recipe, but this only keeps the first instance of a key, discarding any duplicates. Thus avoiding duplicate keys will ensure our nightly feedstock builds are accurately testing the actual recipe. Discovered in https://github.com/TileDB-Inc/conda-forge-nightly-controller/pull/123

Removing both instances of `skip` is an easy decision. Support for win32 was dropped from conda-forge in 2018 (https://github.com/conda-forge/staged-recipes/issues/5640), and support for Python 2 was dropped in 2020 (https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/491).

While using the  `script` key directly in the recipe YAML is convenient (recently introduced in #232), these duplicate keys with jinja2 preprocessing selectors are difficult to programmatically edit (https://github.com/TileDB-Inc/conda-forge-nightly-controller/pull/114, https://github.com/TileDB-Inc/conda-forge-nightly-controller/pull/122). Since using separate build scripts is functionally equivalent, I reverted to this strategy.


This change does not affect the binary itself, so I didn't bump the build number.