### PR TITLE
Also skip problematic test on linux-ppc64le with py39

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
   patches:
     # Skip test that only fails on linux-ppc64le with py310
-    - delete-test-array.patch  # [ppc64le and py==310]
+    - delete-test-array.patch  # [ppc64le and (py==39 or py==310)]
 
 build:
   number: 0


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

---

Does not affect the build in anyway. Did not rerender nor bump the build number

Closes https://github.com/TileDB-Inc/conda-forge-nightly-controller/issues/200

For some reason in the nightly feedstock builds, this problematic test also fails on linux-ppc64le with py39